### PR TITLE
refactor(Binder): use provided closure instead of static bind method

### DIFF
--- a/src/Binder.php
+++ b/src/Binder.php
@@ -16,6 +16,6 @@ class Binder
      */
     public function bind(Closure $algo, HtmlSafeContext $context): Closure|false
     {
-        return Closure::bind($algo, $context) ?? false;
+        return $algo->bind($algo, $context) ?? false;
     }
 }


### PR DESCRIPTION
The static analyzer was complaining.